### PR TITLE
feat: add management api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
 			<artifactId>spring-exceptions</artifactId>
 			<version>1.1.6</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.gycoding</groupId>
+			<artifactId>spring-logs</artifactId>
+			<version>1.0.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/achievements/AchievementIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/achievements/AchievementIDTO.java
@@ -1,9 +1,9 @@
 package org.gycoding.fallofthegods.application.dto.in.achievements;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementOrigin;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementTier;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 
 @Builder
 public record AchievementIDTO(

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/characters/CharacterIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/characters/CharacterIDTO.java
@@ -1,8 +1,7 @@
 package org.gycoding.fallofthegods.application.dto.in.characters;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.application.dto.in.worlds.WorldIDTO;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CharacterIDTO(
@@ -10,7 +9,7 @@ public record CharacterIDTO(
         TranslatedString name,
         TranslatedString title,
         TranslatedString description,
-        WorldIDTO world,
+        String world,
         Boolean inGame,
         String image,
         TranslatedString race

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/creatures/CreatureIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/creatures/CreatureIDTO.java
@@ -1,9 +1,7 @@
 package org.gycoding.fallofthegods.application.dto.in.creatures;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
-
-import java.util.Map;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CreatureIDTO(

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/items/ItemIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/items/ItemIDTO.java
@@ -4,8 +4,6 @@ import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 
-import java.util.List;
-
 @Builder
 public record ItemIDTO(
         String identifier,
@@ -13,6 +11,5 @@ public record ItemIDTO(
         TranslatedString description,
         String image,
         Boolean inGame,
-        ItemType type,
-        List<ItemIDTO> fragments
+        ItemType type
 ) {}

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/items/ItemIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/items/ItemIDTO.java
@@ -1,8 +1,8 @@
 package org.gycoding.fallofthegods.application.dto.in.items;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 
 import java.util.List;
 

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/PlaceIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/PlaceIDTO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.application.dto.in.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record PlaceIDTO(

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/WorldIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/WorldIDTO.java
@@ -13,5 +13,5 @@ public record WorldIDTO(
         String image,
         String detailedIcon,
         String mainColor,
-        List<PlaceIDTO> places
+        List<String> places
 ) {}

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/WorldIDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/in/worlds/WorldIDTO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.application.dto.in.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.List;
 

--- a/src/main/java/org/gycoding/fallofthegods/application/dto/out/items/ItemODTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/dto/out/items/ItemODTO.java
@@ -3,7 +3,6 @@ package org.gycoding.fallofthegods.application.dto.out.items;
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 
-import java.util.List;
 import java.util.Map;
 
 @Builder
@@ -13,8 +12,7 @@ public record ItemODTO(
         String description,
         String image,
         Boolean inGame,
-        ItemType type,
-        List<ItemODTO> fragments
+        ItemType type
 ) {
     public Map<String, Object> toMap() {
         return Map.of(
@@ -22,8 +20,7 @@ public record ItemODTO(
                 "name", name,
                 "description", description,
                 "image", image,
-                "type", type,
-                "fragments", fragments
+                "type", type
         );
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/AchievementServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/AchievementServiceMapper.java
@@ -3,12 +3,14 @@ package org.gycoding.fallofthegods.application.mapper;
 import org.gycoding.fallofthegods.application.dto.in.achievements.AchievementIDTO;
 import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.gycoding.fallofthegods.shared.StringTranslator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", imports = { StringTranslator.class })
+@Mapper(componentModel = "spring", imports = { StringTranslator.class, IdentifierGenerator.class })
 public interface AchievementServiceMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(achievement.name().en()))")
     AchievementMO toMO(AchievementIDTO achievement);
 
     @Mapping(target = "name", expression = "java(StringTranslator.translate(achievement.name(), language))")

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/AchievementServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/AchievementServiceMapper.java
@@ -3,14 +3,12 @@ package org.gycoding.fallofthegods.application.mapper;
 import org.gycoding.fallofthegods.application.dto.in.achievements.AchievementIDTO;
 import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
-import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.gycoding.fallofthegods.shared.StringTranslator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", imports = { StringTranslator.class, IdentifierGenerator.class })
+@Mapper(componentModel = "spring", imports = { StringTranslator.class })
 public interface AchievementServiceMapper {
-    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(achievement.name().en()))")
     AchievementMO toMO(AchievementIDTO achievement);
 
     @Mapping(target = "name", expression = "java(StringTranslator.translate(achievement.name(), language))")

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/CharacterServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/CharacterServiceMapper.java
@@ -3,18 +3,19 @@ package org.gycoding.fallofthegods.application.mapper;
 import org.gycoding.fallofthegods.application.dto.in.characters.CharacterIDTO;
 import org.gycoding.fallofthegods.application.dto.out.characters.CharacterODTO;
 import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.gycoding.fallofthegods.shared.StringTranslator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", imports = { StringTranslator.class })
+@Mapper(componentModel = "spring", imports = { StringTranslator.class, IdentifierGenerator.class })
 public interface CharacterServiceMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(character.name().en()))")
     CharacterMO toMO(CharacterIDTO character);
 
     @Mapping(target = "name", expression = "java(StringTranslator.translate(character.name(), language))")
     @Mapping(target = "title", expression = "java(StringTranslator.translate(character.title(), language))")
     @Mapping(target = "description", expression = "java(StringTranslator.translate(character.description(), language))")
     @Mapping(target = "race", expression = "java(StringTranslator.translate(character.race(), language))")
-    @Mapping(target = "world", source = "character.world.identifier")
     CharacterODTO toODTO(CharacterMO character, String language);
 }

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/CharacterServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/CharacterServiceMapper.java
@@ -3,14 +3,12 @@ package org.gycoding.fallofthegods.application.mapper;
 import org.gycoding.fallofthegods.application.dto.in.characters.CharacterIDTO;
 import org.gycoding.fallofthegods.application.dto.out.characters.CharacterODTO;
 import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
-import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.gycoding.fallofthegods.shared.StringTranslator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", imports = { StringTranslator.class, IdentifierGenerator.class })
+@Mapper(componentModel = "spring", imports = { StringTranslator.class })
 public interface CharacterServiceMapper {
-    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(character.name().en()))")
     CharacterMO toMO(CharacterIDTO character);
 
     @Mapping(target = "name", expression = "java(StringTranslator.translate(character.name(), language))")

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/ItemServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/ItemServiceMapper.java
@@ -7,25 +7,11 @@ import org.gycoding.fallofthegods.shared.StringTranslator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.List;
-
 @Mapper(componentModel = "spring", imports = { StringTranslator.class })
 public interface ItemServiceMapper {
     ItemMO toMO(ItemIDTO item);
 
-    @Mapping(target = "fragments", expression = "java(toItemODTOList(item.fragments(), language))")
     @Mapping(target = "name", expression = "java(StringTranslator.translate(item.name(), language))")
     @Mapping(target = "description", expression = "java(StringTranslator.translate(item.description(), language))")
     ItemODTO toODTO(ItemMO item, String language);
-
-    default List<ItemODTO> toItemODTOList(List<ItemMO> items, String language) {
-        return items.stream()
-                .map(item -> toItemODTO(item, language))
-                .toList();
-    }
-
-    @Mapping(target = "fragments", expression = "java(null)")
-    @Mapping(target = "name", expression = "java(StringTranslator.translate(item.name(), language))")
-    @Mapping(target = "description", expression = "java(StringTranslator.translate(item.description(), language))")
-    ItemODTO toItemODTO(ItemMO item, String language);
 }

--- a/src/main/java/org/gycoding/fallofthegods/application/mapper/WorldServiceMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/mapper/WorldServiceMapper.java
@@ -14,12 +14,14 @@ import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring", imports = { StringTranslator.class })
 public interface WorldServiceMapper {
+    @Mapping(target = "places", ignore = true)
     WorldMO toMO(WorldIDTO world);
 
     @Mapping(target = "name", expression = "java(StringTranslator.translate(world.name(), language))")
     @Mapping(target = "description", expression = "java(StringTranslator.translate(world.description(), language))")
     @Mapping(target = "places", expression = "java(toPlaceODTOList(world.places(), language))")
     WorldODTO toODTO(WorldMO world, String language);
+
     default List<PlaceODTO> toPlaceODTOList(List<PlaceMO> places, String language) {
         return places.stream()
                 .map(place -> toPlaceODTO(place, language))

--- a/src/main/java/org/gycoding/fallofthegods/application/service/AchievementService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/AchievementService.java
@@ -1,15 +1,18 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.achievements.AchievementIDTO;
 import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface AchievementService {
+    AchievementODTO save(AchievementIDTO achievement) throws APIException;
+    void delete(String identifier) throws APIException;
+
     AchievementODTO get(String identifier, String language) throws APIException;
     List<AchievementODTO> list(String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/AchievementService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/AchievementService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public interface AchievementService {
     AchievementODTO save(AchievementIDTO achievement) throws APIException;
+    AchievementODTO update(AchievementIDTO achievement) throws APIException;
     void delete(String identifier) throws APIException;
 
     AchievementODTO get(String identifier, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/CharacterService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/CharacterService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public interface CharacterService {
     CharacterODTO save(CharacterIDTO character) throws APIException;
+    CharacterODTO update(CharacterIDTO character) throws APIException;
     void delete(String identifier) throws APIException;
 
     CharacterODTO get(String identifier, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/CharacterService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/CharacterService.java
@@ -1,15 +1,18 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.characters.CharacterIDTO;
 import org.gycoding.fallofthegods.application.dto.out.characters.CharacterODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface CharacterService {
+    CharacterODTO save(CharacterIDTO character) throws APIException;
+    void delete(String identifier) throws APIException;
+
     CharacterODTO get(String identifier, Boolean inGame, String language) throws APIException;
     List<CharacterODTO> list(Boolean inGame, String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/CreatureService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/CreatureService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public interface CreatureService {
     CreatureODTO save(CreatureIDTO creature) throws APIException;
+    CreatureODTO update(CreatureIDTO creature) throws APIException;
     void delete(String identifier) throws APIException;
 
     CreatureODTO get(String identifier, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/CreatureService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/CreatureService.java
@@ -1,15 +1,18 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.creatures.CreatureIDTO;
 import org.gycoding.fallofthegods.application.dto.out.creatures.CreatureODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface CreatureService {
+    CreatureODTO save(CreatureIDTO creature) throws APIException;
+    void delete(String identifier) throws APIException;
+
     CreatureODTO get(String identifier, Boolean inGame, String language) throws APIException;
     List<CreatureODTO> list(Boolean inGame, String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/ItemService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/ItemService.java
@@ -1,15 +1,18 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.items.ItemIDTO;
 import org.gycoding.fallofthegods.application.dto.out.items.ItemODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface ItemService {
+    ItemODTO save(ItemIDTO item) throws APIException;
+    void delete(String identifier) throws APIException;
+
     ItemODTO get(String identifier, Boolean inGame, String language) throws APIException;
     List<ItemODTO> list(Boolean inGame, String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/ItemService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/ItemService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public interface ItemService {
     ItemODTO save(ItemIDTO item) throws APIException;
+    ItemODTO update(ItemIDTO item) throws APIException;
     void delete(String identifier) throws APIException;
 
     ItemODTO get(String identifier, Boolean inGame, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/PlaceService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/PlaceService.java
@@ -1,15 +1,18 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.worlds.PlaceIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.PlaceODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface PlaceService {
+    PlaceODTO save(PlaceIDTO place) throws APIException;
+    void delete(String identifier) throws APIException;
+
     PlaceODTO get(String identifier, String language) throws APIException;
     List<PlaceODTO> list(String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/PlaceService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/PlaceService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public interface PlaceService {
     PlaceODTO save(PlaceIDTO place) throws APIException;
+    PlaceODTO update(PlaceIDTO place) throws APIException;
     void delete(String identifier) throws APIException;
 
     PlaceODTO get(String identifier, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/WorldService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/WorldService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public interface WorldService {
     WorldODTO save(WorldIDTO world) throws APIException;
+    WorldODTO update(WorldIDTO world) throws APIException;
     void delete(String identifier) throws APIException;
 
     WorldODTO get(String identifier, String language) throws APIException;

--- a/src/main/java/org/gycoding/fallofthegods/application/service/WorldService.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/WorldService.java
@@ -1,20 +1,23 @@
 package org.gycoding.fallofthegods.application.service;
 
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.worlds.WorldIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.PlaceODTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.WorldODTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 public interface WorldService {
+    WorldODTO save(WorldIDTO world) throws APIException;
+    void delete(String identifier) throws APIException;
+
     WorldODTO get(String identifier, String language) throws APIException;
     List<WorldODTO> list(String language) throws APIException;
     Page<Map<String, Object>> page(Pageable pageable, String language) throws APIException;
-    PlaceODTO getPlace(String idWorld, String idPlace, String language) throws APIException;
+
     List<PlaceODTO> listPlaces(String idWorld, String language) throws APIException;
     Page<Map<String, Object>> pagePlaces(String idWorld, Pageable pageable, String language) throws APIException;
 }

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/AchievementServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/AchievementServiceImpl.java
@@ -45,6 +45,23 @@ public class AchievementServiceImpl implements AchievementService {
     }
 
     @Override
+    public AchievementODTO update(AchievementIDTO achievement) throws APIException {
+        final AchievementMO updatedAchievement;
+
+        try {
+            updatedAchievement = repository.update(mapper.toMO(achievement));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedAchievement, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/AchievementServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/AchievementServiceImpl.java
@@ -3,10 +3,13 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.achievements.AchievementIDTO;
 import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.gycoding.fallofthegods.application.mapper.AchievementServiceMapper;
 import org.gycoding.fallofthegods.application.service.AchievementService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.gycoding.fallofthegods.domain.repository.AchievementRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -24,6 +27,37 @@ public class AchievementServiceImpl implements AchievementService {
 
     private final AchievementServiceMapper mapper;
 
+    @Override
+    public AchievementODTO save(AchievementIDTO achievement) throws APIException {
+        final AchievementMO savedAchievement;
+
+        try {
+            savedAchievement = repository.save(mapper.toMO(achievement));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedAchievement, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
+
+    @Override
     public AchievementODTO get(String identifier, String language) throws APIException {
         final var achievement = repository.get(identifier).orElseThrow(() ->
                 new APIException(
@@ -36,6 +70,7 @@ public class AchievementServiceImpl implements AchievementService {
         return mapper.toODTO(achievement, language);
     }
 
+    @Override
     public List<AchievementODTO> list(String language) throws APIException {
         try {
             final var achievements = repository.list();
@@ -50,6 +85,7 @@ public class AchievementServiceImpl implements AchievementService {
         }
     }
 
+    @Override
     public Page<Map<String, Object>> page(Pageable pageable, String language) throws APIException {
         try {
             final var achievements = repository.page(pageable);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
@@ -11,7 +11,6 @@ import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
 import org.gycoding.fallofthegods.domain.repository.CharacterRepository;
-import org.gycoding.fallofthegods.domain.repository.WorldRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +26,6 @@ public class CharacterServiceImpl implements CharacterService {
     private final CharacterRepository repository;
 
     private final CharacterServiceMapper mapper;
-
-    private final WorldRepository worldRepository;
 
     @Override
     public CharacterODTO save(CharacterIDTO character) throws APIException {

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
@@ -3,11 +3,15 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.characters.CharacterIDTO;
 import org.gycoding.fallofthegods.application.dto.out.characters.CharacterODTO;
 import org.gycoding.fallofthegods.application.mapper.CharacterServiceMapper;
 import org.gycoding.fallofthegods.application.service.CharacterService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
 import org.gycoding.fallofthegods.domain.repository.CharacterRepository;
+import org.gycoding.fallofthegods.domain.repository.WorldRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +27,38 @@ public class CharacterServiceImpl implements CharacterService {
     private final CharacterRepository repository;
 
     private final CharacterServiceMapper mapper;
+
+    private final WorldRepository worldRepository;
+
+    @Override
+    public CharacterODTO save(CharacterIDTO character) throws APIException {
+        final CharacterMO savedCharacter;
+
+        try {
+            savedCharacter = repository.save(mapper.toMO(character));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedCharacter, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
 
     @Override
     public CharacterODTO get(String identifier, Boolean inGame, String language) throws APIException {
@@ -42,7 +78,9 @@ public class CharacterServiceImpl implements CharacterService {
         try {
             final var characters = repository.list(inGame);
 
-            return characters.stream().map(character -> mapper.toODTO(character, language)).toList();
+            return characters.stream()
+                    .map(character -> mapper.toODTO(character, language))
+                    .toList();
         } catch (NullPointerException e) {
             throw new APIException(
                     FOTGAPIError.RESOURCE_NOT_FOUND.code,
@@ -57,7 +95,13 @@ public class CharacterServiceImpl implements CharacterService {
         try {
             final var characters = repository.page(pageable, inGame);
 
-            return PagingConverter.listToPage(characters.stream().map(character -> mapper.toODTO(character, language)).map(CharacterODTO::toMap).toList(), pageable);
+            return PagingConverter.listToPage(
+                    characters.stream()
+                            .map(character -> mapper.toODTO(character, language))
+                            .map(CharacterODTO::toMap)
+                            .toList(),
+                    pageable
+            );
         } catch (NullPointerException e) {
             throw new APIException(
                     FOTGAPIError.RESOURCE_NOT_FOUND.code,

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/CharacterServiceImpl.java
@@ -45,6 +45,23 @@ public class CharacterServiceImpl implements CharacterService {
     }
 
     @Override
+    public CharacterODTO update(CharacterIDTO character) throws APIException {
+        final CharacterMO updatedCharacter;
+
+        try {
+            updatedCharacter = repository.update(mapper.toMO(character));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedCharacter, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/CreatureServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/CreatureServiceImpl.java
@@ -45,6 +45,23 @@ public class CreatureServiceImpl implements CreatureService {
     }
 
     @Override
+    public CreatureODTO update(CreatureIDTO creature) throws APIException {
+        final CreatureMO updatedCreature;
+
+        try {
+            updatedCreature = repository.update(mapper.toMO(creature));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedCreature, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/CreatureServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/CreatureServiceImpl.java
@@ -3,10 +3,13 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.creatures.CreatureIDTO;
 import org.gycoding.fallofthegods.application.dto.out.creatures.CreatureODTO;
 import org.gycoding.fallofthegods.application.mapper.CreatureServiceMapper;
 import org.gycoding.fallofthegods.application.service.CreatureService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.gycoding.fallofthegods.domain.repository.CreatureRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -23,6 +26,36 @@ public class CreatureServiceImpl implements CreatureService {
     private final CreatureRepository repository;
 
     private final CreatureServiceMapper mapper;
+
+    @Override
+    public CreatureODTO save(CreatureIDTO creature) throws APIException {
+        final CreatureMO savedCreature;
+
+        try {
+            savedCreature = repository.save(mapper.toMO(creature));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedCreature, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
 
     @Override
     public CreatureODTO get(String identifier, Boolean inGame, String language) throws APIException {

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/ItemServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/ItemServiceImpl.java
@@ -3,10 +3,13 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.items.ItemIDTO;
 import org.gycoding.fallofthegods.application.dto.out.items.ItemODTO;
 import org.gycoding.fallofthegods.application.mapper.ItemServiceMapper;
 import org.gycoding.fallofthegods.application.service.ItemService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.gycoding.fallofthegods.domain.repository.ItemRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -23,6 +26,36 @@ public class ItemServiceImpl implements ItemService {
     private final ItemRepository repository;
 
     private final ItemServiceMapper mapper;
+
+    @Override
+    public ItemODTO save(ItemIDTO item) throws APIException {
+        final ItemMO savedItem;
+
+        try {
+            savedItem = repository.save(mapper.toMO(item));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedItem, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
 
     @Override
     public ItemODTO get(String identifier, Boolean inGame, String language) throws APIException {

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/ItemServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/ItemServiceImpl.java
@@ -45,6 +45,23 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
+    public ItemODTO update(ItemIDTO item) throws APIException {
+        final ItemMO updatedItem;
+
+        try {
+            updatedItem = repository.update(mapper.toMO(item));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedItem, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/PlaceServiceImpl.java
@@ -45,6 +45,23 @@ public class PlaceServiceImpl implements PlaceService {
     }
 
     @Override
+    public PlaceODTO update(PlaceIDTO place) throws APIException {
+        final PlaceMO updatedPlace;
+
+        try {
+            updatedPlace = repository.update(mapper.toMO(place));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedPlace, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/PlaceServiceImpl.java
@@ -3,10 +3,13 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.worlds.PlaceIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.PlaceODTO;
 import org.gycoding.fallofthegods.application.mapper.PlaceServiceMapper;
 import org.gycoding.fallofthegods.application.service.PlaceService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.gycoding.fallofthegods.domain.repository.PlaceRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -23,6 +26,36 @@ public class PlaceServiceImpl implements PlaceService {
     private final PlaceRepository repository;
 
     private final PlaceServiceMapper mapper;
+
+    @Override
+    public PlaceODTO save(PlaceIDTO place) throws APIException {
+        final PlaceMO savedPlace;
+
+        try {
+            savedPlace = repository.save(mapper.toMO(place));
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedPlace, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
 
     @Override
     public PlaceODTO get(String identifier, String language) throws APIException {

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/WorldServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/WorldServiceImpl.java
@@ -46,6 +46,23 @@ public class WorldServiceImpl implements WorldService {
     }
 
     @Override
+    public WorldODTO update(WorldIDTO world) throws APIException {
+        final WorldMO updatedWorld;
+
+        try {
+            updatedWorld = repository.update(mapper.toMO(world), world.places());
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(updatedWorld, TranslatedString.EN);
+    }
+
+    @Override
     public void delete(String identifier) throws APIException {
         try {
             repository.delete(identifier);

--- a/src/main/java/org/gycoding/fallofthegods/application/service/impl/WorldServiceImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/application/service/impl/WorldServiceImpl.java
@@ -3,11 +3,14 @@ package org.gycoding.fallofthegods.application.service.impl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.dto.in.worlds.WorldIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.PlaceODTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.WorldODTO;
 import org.gycoding.fallofthegods.application.mapper.WorldServiceMapper;
 import org.gycoding.fallofthegods.application.service.WorldService;
 import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
 import org.gycoding.fallofthegods.domain.repository.WorldRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -25,6 +28,37 @@ public class WorldServiceImpl implements WorldService {
 
     private final WorldServiceMapper mapper;
 
+    @Override
+    public WorldODTO save(WorldIDTO world) throws APIException {
+        final WorldMO savedWorld;
+
+        try {
+            savedWorld = repository.save(mapper.toMO(world), world.places());
+        } catch(Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+
+        return mapper.toODTO(savedWorld, TranslatedString.EN);
+    }
+
+    @Override
+    public void delete(String identifier) throws APIException {
+        try {
+            repository.delete(identifier);
+        } catch (Exception e) {
+            throw new APIException(
+                    FOTGAPIError.CONFLICT.code,
+                    FOTGAPIError.CONFLICT.message,
+                    FOTGAPIError.CONFLICT.status
+            );
+        }
+    }
+
+    @Override
     public WorldODTO get(String identifier, String language) throws APIException {
         final var world = repository.get(identifier).orElseThrow(() ->
                 new APIException(
@@ -37,6 +71,7 @@ public class WorldServiceImpl implements WorldService {
         return mapper.toODTO(world, language);
     }
 
+    @Override
     public List<WorldODTO> list(String language) throws APIException {
         try {
             final var worlds = repository.list();
@@ -51,6 +86,7 @@ public class WorldServiceImpl implements WorldService {
         }
     }
 
+    @Override
     public Page<Map<String, Object>> page(Pageable pageable, String language) throws APIException {
         try {
             final var worlds = repository.page(pageable);
@@ -63,22 +99,6 @@ public class WorldServiceImpl implements WorldService {
                     FOTGAPIError.RESOURCE_NOT_FOUND.status
             );
         }
-    }
-
-    @Override
-    public PlaceODTO getPlace(String idWorld, String idPlace, String language) throws APIException {
-        final var world = this.get(idWorld, language);
-
-        return world.places().stream()
-                .filter(place -> place.identifier().equals(idPlace))
-                .findFirst()
-                .orElseThrow(() ->
-                    new APIException(
-                            FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                            FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                            FOTGAPIError.RESOURCE_NOT_FOUND.status
-                    )
-                );
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/TranslatedString.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/TranslatedString.java
@@ -1,4 +1,4 @@
-package org.gycoding.fallofthegods.infrastructure.external.database.model;
+package org.gycoding.fallofthegods.domain.model;
 
 import lombok.Builder;
 
@@ -7,6 +7,9 @@ public record TranslatedString (
         String es,
         String en
 ) {
+    public static String EN = "en";
+    public static String ES = "es";
+
     public String get(String language) {
         return switch (language) {
             case "en" -> en;

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/achievements/AchievementMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/achievements/AchievementMO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.achievements;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record AchievementMO(

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/characters/CharacterMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/characters/CharacterMO.java
@@ -1,8 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.characters;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CharacterMO(
@@ -10,7 +9,7 @@ public record CharacterMO(
         TranslatedString name,
         TranslatedString title,
         TranslatedString description,
-        WorldMO world,
+        String world,
         Boolean inGame,
         String image,
         TranslatedString race

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/creatures/CreatureMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/creatures/CreatureMO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.creatures;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CreatureMO(

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/items/ItemMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/items/ItemMO.java
@@ -3,8 +3,6 @@ package org.gycoding.fallofthegods.domain.model.items;
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
-import java.util.List;
-
 @Builder
 public record ItemMO(
     String identifier,
@@ -12,6 +10,5 @@ public record ItemMO(
     TranslatedString description,
     String image,
     Boolean inGame,
-    ItemType type,
-    List<ItemMO> fragments
+    ItemType type
 ) {}

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/items/ItemMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/items/ItemMO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.items;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.List;
 

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/worlds/PlaceMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/worlds/PlaceMO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record PlaceMO(

--- a/src/main/java/org/gycoding/fallofthegods/domain/model/worlds/WorldMO.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/model/worlds/WorldMO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.domain.model.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.List;
 

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
@@ -1,6 +1,5 @@
 package org.gycoding.fallofthegods.domain.repository;
 
-import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +10,10 @@ import java.util.Optional;
 
 @Repository
 public interface AchievementRepository {
-    AchievementMO save(AchievementMO entity) throws APIException;
-    Optional<AchievementMO> get(String identifier) throws APIException;
-    List<AchievementMO> list() throws APIException;
-    Page<AchievementMO> page(Pageable pageable) throws APIException;
-    void delete(String identifier) throws APIException;
+    AchievementMO save(AchievementMO entity);
+    void delete(String identifier);
+
+    Optional<AchievementMO> get(String identifier);
+    List<AchievementMO> list();
+    Page<AchievementMO> page(Pageable pageable);
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
@@ -1,5 +1,6 @@
 package org.gycoding.fallofthegods.domain.repository;
 
+import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface AchievementRepository {
     AchievementMO save(AchievementMO achievement);
+    AchievementMO update(AchievementMO achievement) throws APIException;
     void delete(String identifier);
 
     Optional<AchievementMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/AchievementRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface AchievementRepository {
-    AchievementMO save(AchievementMO entity);
+    AchievementMO save(AchievementMO achievement);
     void delete(String identifier);
 
     Optional<AchievementMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface CharacterRepository {
     CharacterMO save(CharacterMO character) throws APIException;
+    CharacterMO update(CharacterMO character) throws APIException;
     void delete(String identifier);
 
     Optional<CharacterMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
@@ -12,11 +12,12 @@ import java.util.Optional;
 @Repository
 public interface CharacterRepository {
     CharacterMO save(CharacterMO entity) throws APIException;
-    Optional<CharacterMO> get(String identifier) throws APIException;
-    Optional<CharacterMO> get(String identifier, Boolean inGame) throws APIException;
-    List<CharacterMO> list() throws APIException;
-    List<CharacterMO> list(Boolean inGame) throws APIException;
-    Page<CharacterMO> page(Pageable pageable) throws APIException;
-    Page<CharacterMO> page(Pageable pageable, Boolean inGame) throws APIException;
-    void delete(String identifier) throws APIException;
+    void delete(String identifier);
+
+    Optional<CharacterMO> get(String identifier);
+    Optional<CharacterMO> get(String identifier, Boolean inGame);
+    List<CharacterMO> list();
+    List<CharacterMO> list(Boolean inGame);
+    Page<CharacterMO> page(Pageable pageable);
+    Page<CharacterMO> page(Pageable pageable, Boolean inGame);
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/CharacterRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface CharacterRepository {
-    CharacterMO save(CharacterMO entity) throws APIException;
+    CharacterMO save(CharacterMO character) throws APIException;
     void delete(String identifier);
 
     Optional<CharacterMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/CreatureRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/CreatureRepository.java
@@ -1,5 +1,6 @@
 package org.gycoding.fallofthegods.domain.repository;
 
+import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface CreatureRepository {
     CreatureMO save(CreatureMO creature);
+    CreatureMO update(CreatureMO creature) throws APIException;
     void delete(String identifier);
 
     Optional<CreatureMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/CreatureRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/CreatureRepository.java
@@ -1,6 +1,5 @@
 package org.gycoding.fallofthegods.domain.repository;
 
-import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,12 +10,13 @@ import java.util.Optional;
 
 @Repository
 public interface CreatureRepository {
-    CreatureMO save(CreatureMO entity) throws APIException;
-    Optional<CreatureMO> get(String identifier) throws APIException;
-    Optional<CreatureMO> get(String identifier, Boolean inGame) throws APIException;
-    List<CreatureMO> list() throws APIException;
-    List<CreatureMO> list(Boolean inGame) throws APIException;
-    Page<CreatureMO> page(Pageable pageable) throws APIException;
-    Page<CreatureMO> page(Pageable pageable, Boolean inGame) throws APIException;
-    void delete(String identifier) throws APIException;
+    CreatureMO save(CreatureMO creature);
+    void delete(String identifier);
+
+    Optional<CreatureMO> get(String identifier);
+    Optional<CreatureMO> get(String identifier, Boolean inGame);
+    List<CreatureMO> list();
+    List<CreatureMO> list(Boolean inGame);
+    Page<CreatureMO> page(Pageable pageable);
+    Page<CreatureMO> page(Pageable pageable, Boolean inGame);
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/ItemRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/ItemRepository.java
@@ -1,5 +1,6 @@
 package org.gycoding.fallofthegods.domain.repository;
 
+import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface ItemRepository {
     ItemMO save(ItemMO item);
+    ItemMO update(ItemMO item) throws APIException;
     void delete(String identifier);
 
     Optional<ItemMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/ItemRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/ItemRepository.java
@@ -1,6 +1,5 @@
 package org.gycoding.fallofthegods.domain.repository;
 
-import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,12 +10,14 @@ import java.util.Optional;
 
 @Repository
 public interface ItemRepository {
-    ItemMO save(ItemMO entity) throws APIException;
-    Optional<ItemMO> get(String identifier) throws APIException;
-    Optional<ItemMO> get(String identifier, Boolean inGame) throws APIException;
-    List<ItemMO> list() throws APIException;
-    List<ItemMO> list(Boolean inGame) throws APIException;
-    Page<ItemMO> page(Pageable pageable) throws APIException;
-    Page<ItemMO> page(Pageable pageable, Boolean inGame) throws APIException;
-    void delete(String identifier) throws APIException;
+    ItemMO save(ItemMO item);
+    void delete(String identifier);
+
+    Optional<ItemMO> get(String identifier);
+    Optional<ItemMO> get(String identifier, Boolean inGame);
+    List<ItemMO> list();
+    List<ItemMO> list(Boolean inGame);
+    Page<ItemMO> page(Pageable pageable);
+    Page<ItemMO> page(Pageable pageable, Boolean inGame);
+
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/PlaceRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/PlaceRepository.java
@@ -1,5 +1,6 @@
 package org.gycoding.fallofthegods.domain.repository;
 
+import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface PlaceRepository {
     PlaceMO save(PlaceMO entity);
+    PlaceMO update(PlaceMO entity) throws APIException;
     void delete(String identifier);
 
     Optional<PlaceMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/PlaceRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/PlaceRepository.java
@@ -1,7 +1,5 @@
 package org.gycoding.fallofthegods.domain.repository;
 
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,12 +10,13 @@ import java.util.Optional;
 
 @Repository
 public interface PlaceRepository {
-    PlaceMO save(PlaceMO entity) throws APIException;
-    Optional<PlaceMO> get(String identifier) throws APIException;
-    Optional<PlaceMO> get(String identifier, Boolean inGame) throws APIException;
-    List<PlaceMO> list() throws APIException;
-    List<PlaceMO> list(Boolean inGame) throws APIException;
-    Page<PlaceMO> page(Pageable pageable) throws APIException;
-    Page<PlaceMO> page(Pageable pageable, Boolean inGame) throws APIException;
-    void delete(String identifier) throws APIException;
+    PlaceMO save(PlaceMO entity);
+    void delete(String identifier);
+
+    Optional<PlaceMO> get(String identifier);
+    Optional<PlaceMO> get(String identifier, Boolean inGame);
+    List<PlaceMO> list();
+    List<PlaceMO> list(Boolean inGame);
+    Page<PlaceMO> page(Pageable pageable);
+    Page<PlaceMO> page(Pageable pageable, Boolean inGame);
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/WorldRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/WorldRepository.java
@@ -11,9 +11,10 @@ import java.util.Optional;
 
 @Repository
 public interface WorldRepository {
-    WorldMO save(WorldMO entity) throws APIException;
-    Optional<WorldMO> get(String identifier) throws APIException;
-    List<WorldMO> list() throws APIException;
-    Page<WorldMO> page(Pageable pageable) throws APIException;
-    void delete(String identifier) throws APIException;
+    WorldMO save(WorldMO world, List<String> places) throws APIException;
+    void delete(String identifier);
+
+    Optional<WorldMO> get(String identifier);
+    List<WorldMO> list();
+    Page<WorldMO> page(Pageable pageable);
 }

--- a/src/main/java/org/gycoding/fallofthegods/domain/repository/WorldRepository.java
+++ b/src/main/java/org/gycoding/fallofthegods/domain/repository/WorldRepository.java
@@ -11,7 +11,8 @@ import java.util.Optional;
 
 @Repository
 public interface WorldRepository {
-    WorldMO save(WorldMO world, List<String> places) throws APIException;
+    WorldMO save(WorldMO world, List<String> places);
+    WorldMO update(WorldMO world, List<String> places) throws APIException;
     void delete(String identifier);
 
     Optional<WorldMO> get(String identifier);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/AchievementDataController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/AchievementDataController.java
@@ -1,8 +1,8 @@
-package org.gycoding.fallofthegods.infrastructure.api.controller;
+package org.gycoding.fallofthegods.infrastructure.api.controller.data;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.fallofthegods.application.service.AchievementService;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.AchievementService;
 import org.gycoding.fallofthegods.infrastructure.api.mapper.AchievementControllerMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/achievements")
 @AllArgsConstructor
-public class AchievementController {
+public class AchievementDataController {
     private final AchievementService service;
 
     private final AchievementControllerMapper mapper;

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/CharacterDataController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/CharacterDataController.java
@@ -1,9 +1,9 @@
-package org.gycoding.fallofthegods.infrastructure.api.controller;
+package org.gycoding.fallofthegods.infrastructure.api.controller.data;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.fallofthegods.application.service.ItemService;
 import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.infrastructure.api.mapper.ItemControllerMapper;
+import org.gycoding.fallofthegods.application.service.CharacterService;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.CharacterControllerMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,40 +12,40 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/items")
+@RequestMapping("/characters")
 @AllArgsConstructor
-public class ItemController {
-    private final ItemService service;
+public class CharacterDataController {
+    private final CharacterService service;
 
-    private final ItemControllerMapper mapper;
+    private final CharacterControllerMapper mapper;
 
     @GetMapping("/story/get")
-    public ResponseEntity<?> getStoryItem(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getStoryCharacter(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, false, lang)));
     }
 
     @GetMapping("/story/list")
-    public ResponseEntity<?> listStoryItems(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listStoryCharacters(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(false, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/story/page")
-    public ResponseEntity<?> pageStoryItems(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageStoryCharacters(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, false, lang).getContent());
     }
 
     @GetMapping("/game/get")
-    public ResponseEntity<?> getGameItem(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getGameCharacter(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, true, lang)));
     }
 
     @GetMapping("/game/list")
-    public ResponseEntity<?> listGameItems(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listGameCharacters(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(true, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/game/page")
-    public ResponseEntity<?> pageGameItems(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageGameCharacters(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, true, lang).getContent());
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/CreatureDataController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/CreatureDataController.java
@@ -1,9 +1,9 @@
-package org.gycoding.fallofthegods.infrastructure.api.controller;
+package org.gycoding.fallofthegods.infrastructure.api.controller.data;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.fallofthegods.application.service.CharacterService;
 import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.infrastructure.api.mapper.CharacterControllerMapper;
+import org.gycoding.fallofthegods.application.service.CreatureService;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.CreatureControllerMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,40 +12,40 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/characters")
+@RequestMapping("/creatures")
 @AllArgsConstructor
-public class CharacterController {
-    private final CharacterService service;
+public class CreatureDataController {
+    private final CreatureService service;
 
-    private final CharacterControllerMapper mapper;
+    private final CreatureControllerMapper mapper;
 
     @GetMapping("/story/get")
-    public ResponseEntity<?> getStoryCharacter(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getStoryCreature(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, false, lang)));
     }
 
     @GetMapping("/story/list")
-    public ResponseEntity<?> listStoryCharacters(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listStoryCreatures(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(false, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/story/page")
-    public ResponseEntity<?> pageStoryCharacters(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageStoryCreatures(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, false, lang).getContent());
     }
 
     @GetMapping("/game/get")
-    public ResponseEntity<?> getGameCharacter(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getGameCreature(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, true, lang)));
     }
 
     @GetMapping("/game/list")
-    public ResponseEntity<?> listGameCharacters(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listGameCreatures(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(true, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/game/page")
-    public ResponseEntity<?> pageGameCharacters(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageGameCreatures(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, true, lang).getContent());
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/ItemDataController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/ItemDataController.java
@@ -1,9 +1,9 @@
-package org.gycoding.fallofthegods.infrastructure.api.controller;
+package org.gycoding.fallofthegods.infrastructure.api.controller.data;
 
 import lombok.AllArgsConstructor;
 import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.application.service.CreatureService;
-import org.gycoding.fallofthegods.infrastructure.api.mapper.CreatureControllerMapper;
+import org.gycoding.fallofthegods.application.service.ItemService;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.ItemControllerMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,40 +12,40 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/creatures")
+@RequestMapping("/items")
 @AllArgsConstructor
-public class CreatureController {
-    private final CreatureService service;
+public class ItemDataController {
+    private final ItemService service;
 
-    private final CreatureControllerMapper mapper;
+    private final ItemControllerMapper mapper;
 
     @GetMapping("/story/get")
-    public ResponseEntity<?> getStoryCreature(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getStoryItem(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, false, lang)));
     }
 
     @GetMapping("/story/list")
-    public ResponseEntity<?> listStoryCreatures(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listStoryItems(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(false, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/story/page")
-    public ResponseEntity<?> pageStoryCreatures(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageStoryItems(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, false, lang).getContent());
     }
 
     @GetMapping("/game/get")
-    public ResponseEntity<?> getGameCreature(@RequestParam String id, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> getGameItem(@RequestParam String id, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.get(id, true, lang)));
     }
 
     @GetMapping("/game/list")
-    public ResponseEntity<?> listGameCreatures(@RequestParam String lang) throws APIException {
+    public ResponseEntity<?> listGameItems(@RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.list(true, lang).stream().map(mapper::toRSDTO).toList());
     }
 
     @GetMapping("/game/page")
-    public ResponseEntity<?> pageGameCreatures(Pageable pageable, @RequestParam String lang) throws APIException {
+    public ResponseEntity<?> pageGameItems(Pageable pageable, @RequestParam String lang) throws APIException {
         return ResponseEntity.ok(service.page(pageable, true, lang).getContent());
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/WorldDataController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/data/WorldDataController.java
@@ -1,9 +1,9 @@
-package org.gycoding.fallofthegods.infrastructure.api.controller;
+package org.gycoding.fallofthegods.infrastructure.api.controller.data;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.application.service.PlaceService;
 import org.gycoding.fallofthegods.application.service.WorldService;
-import org.gycoding.exceptions.model.APIException;
 import org.gycoding.fallofthegods.infrastructure.api.mapper.PlaceControllerMapper;
 import org.gycoding.fallofthegods.infrastructure.api.mapper.WorldControllerMapper;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/worlds")
 @AllArgsConstructor
-public class WorldController {
+public class WorldDataController {
     private final WorldService worldService;
 
     private final PlaceService placeService;

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
@@ -1,0 +1,30 @@
+package org.gycoding.fallofthegods.infrastructure.api.controller.management;
+
+import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.AchievementService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.achievements.AchievementRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.AchievementControllerMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/achievements")
+@AllArgsConstructor
+public class AchievementManagementController {
+    private final AchievementService service;
+
+    private final AchievementControllerMapper mapper;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveAchievement(@RequestBody AchievementRQDTO achievement) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(achievement))));
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<?> removeAchievement(@RequestParam String id) throws APIException {
+        service.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
@@ -21,6 +21,11 @@ public class AchievementManagementController {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(achievement))));
     }
 
+    @PatchMapping("")
+    public ResponseEntity<?> update(@RequestBody AchievementRQDTO achievement, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.update(mapper.toIDTO(achievement, id))));
+    }
+
     @DeleteMapping("")
     public ResponseEntity<?> removeAchievement(@RequestParam String id) throws APIException {
         service.delete(id);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/AchievementManagementController.java
@@ -17,7 +17,7 @@ public class AchievementManagementController {
     private final AchievementControllerMapper mapper;
 
     @PostMapping("")
-    public ResponseEntity<?> saveAchievement(@RequestBody AchievementRQDTO achievement) throws APIException {
+    public ResponseEntity<?> save(@RequestBody AchievementRQDTO achievement) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(achievement))));
     }
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
@@ -22,7 +22,7 @@ public class CharacterManagementController {
     }
 
     @DeleteMapping("")
-    public ResponseEntity<?> removeCharacters(@RequestParam String id) throws APIException {
+    public ResponseEntity<?> removeCharacter(@RequestParam String id) throws APIException {
         service.delete(id);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
@@ -17,8 +17,13 @@ public class CharacterManagementController {
     private final CharacterControllerMapper mapper;
 
     @PostMapping("")
-    public ResponseEntity<?> saveCharacter(@RequestBody CharacterRQDTO character) throws APIException {
+    public ResponseEntity<?> save(@RequestBody CharacterRQDTO character) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(character))));
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<?> update(@RequestBody CharacterRQDTO character, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.update(mapper.toIDTO(character, id))));
     }
 
     @DeleteMapping("")

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CharacterManagementController.java
@@ -1,0 +1,30 @@
+package org.gycoding.fallofthegods.infrastructure.api.controller.management;
+
+import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.CharacterService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.characters.CharacterRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.CharacterControllerMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/characters")
+@AllArgsConstructor
+public class CharacterManagementController {
+    private final CharacterService service;
+
+    private final CharacterControllerMapper mapper;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveCharacter(@RequestBody CharacterRQDTO character) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(character))));
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<?> removeCharacters(@RequestParam String id) throws APIException {
+        service.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
@@ -1,0 +1,30 @@
+package org.gycoding.fallofthegods.infrastructure.api.controller.management;
+
+import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.CreatureService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.creatures.CreatureRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.CreatureControllerMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/creatures")
+@AllArgsConstructor
+public class CreatureManagementController {
+    private final CreatureService service;
+
+    private final CreatureControllerMapper mapper;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveCreature(@RequestBody CreatureRQDTO creature) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(creature))));
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<?> removeCreature(@RequestParam String id) throws APIException {
+        service.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
@@ -17,7 +17,7 @@ public class CreatureManagementController {
     private final CreatureControllerMapper mapper;
 
     @PostMapping("")
-    public ResponseEntity<?> saveCreature(@RequestBody CreatureRQDTO creature) throws APIException {
+    public ResponseEntity<?> save(@RequestBody CreatureRQDTO creature) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(creature))));
     }
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/CreatureManagementController.java
@@ -21,6 +21,11 @@ public class CreatureManagementController {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(creature))));
     }
 
+    @PatchMapping("")
+    public ResponseEntity<?> update(@RequestBody CreatureRQDTO creature, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.update(mapper.toIDTO(creature, id))));
+    }
+
     @DeleteMapping("")
     public ResponseEntity<?> removeCreature(@RequestParam String id) throws APIException {
         service.delete(id);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
@@ -17,7 +17,7 @@ public class ItemManagementController {
     private final ItemControllerMapper mapper;
 
     @PostMapping("")
-    public ResponseEntity<?> saveItem(@RequestBody ItemRQDTO item) throws APIException {
+    public ResponseEntity<?> save(@RequestBody ItemRQDTO item) throws APIException {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(item))));
     }
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
@@ -21,6 +21,11 @@ public class ItemManagementController {
         return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(item))));
     }
 
+    @PatchMapping("")
+    public ResponseEntity<?> update(@RequestBody ItemRQDTO item, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.update(mapper.toIDTO(item, id))));
+    }
+
     @DeleteMapping("")
     public ResponseEntity<?> removeItem(@RequestParam String id) throws APIException {
         service.delete(id);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/ItemManagementController.java
@@ -1,0 +1,30 @@
+package org.gycoding.fallofthegods.infrastructure.api.controller.management;
+
+import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.ItemService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.items.ItemRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.ItemControllerMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/items")
+@AllArgsConstructor
+public class ItemManagementController {
+    private final ItemService service;
+
+    private final ItemControllerMapper mapper;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveItem(@RequestBody ItemRQDTO item) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(item))));
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<?> removeItem(@RequestParam String id) throws APIException {
+        service.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
@@ -28,6 +28,11 @@ public class WorldManagementController {
         return ResponseEntity.ok(worldMapper.toRSDTO(worldService.save(worldMapper.toIDTO(world))));
     }
 
+    @PatchMapping("")
+    public ResponseEntity<?> update(@RequestBody WorldRQDTO world, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(worldMapper.toRSDTO(worldService.update(worldMapper.toIDTO(world, id))));
+    }
+
     @DeleteMapping("")
     public ResponseEntity<?> removeWorld(@RequestParam String id) throws APIException {
         worldService.delete(id);
@@ -38,6 +43,11 @@ public class WorldManagementController {
     @PostMapping("/places")
     public ResponseEntity<?> save(@RequestBody PlaceRQDTO place) throws APIException {
         return ResponseEntity.ok(placeMapper.toRSDTO(placeService.save(placeMapper.toIDTO(place))));
+    }
+
+    @PatchMapping("/places")
+    public ResponseEntity<?> update(@RequestBody PlaceRQDTO place, @RequestParam String id) throws APIException {
+        return ResponseEntity.ok(placeMapper.toRSDTO(placeService.update(placeMapper.toIDTO(place, id))));
     }
 
     @DeleteMapping("/places")

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
@@ -1,0 +1,30 @@
+package org.gycoding.fallofthegods.infrastructure.api.controller.management;
+
+import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.WorldService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.WorldRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.WorldControllerMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/worlds")
+@AllArgsConstructor
+public class WorldManagementController {
+    private final WorldService service;
+
+    private final WorldControllerMapper mapper;
+
+    @PostMapping("")
+    public ResponseEntity<?> saveWorld(@RequestBody WorldRQDTO world) throws APIException {
+        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(world))));
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<?> removeWorld(@RequestParam String id) throws APIException {
+        service.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/controller/management/WorldManagementController.java
@@ -2,8 +2,11 @@ package org.gycoding.fallofthegods.infrastructure.api.controller.management;
 
 import lombok.AllArgsConstructor;
 import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.application.service.PlaceService;
 import org.gycoding.fallofthegods.application.service.WorldService;
+import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.PlaceRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.WorldRQDTO;
+import org.gycoding.fallofthegods.infrastructure.api.mapper.PlaceControllerMapper;
 import org.gycoding.fallofthegods.infrastructure.api.mapper.WorldControllerMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,18 +15,34 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/worlds")
 @AllArgsConstructor
 public class WorldManagementController {
-    private final WorldService service;
+    private final WorldService worldService;
 
-    private final WorldControllerMapper mapper;
+    private final WorldControllerMapper worldMapper;
+
+    private final PlaceService placeService;
+
+    private final PlaceControllerMapper placeMapper;
 
     @PostMapping("")
-    public ResponseEntity<?> saveWorld(@RequestBody WorldRQDTO world) throws APIException {
-        return ResponseEntity.ok(mapper.toRSDTO(service.save(mapper.toIDTO(world))));
+    public ResponseEntity<?> save(@RequestBody WorldRQDTO world) throws APIException {
+        return ResponseEntity.ok(worldMapper.toRSDTO(worldService.save(worldMapper.toIDTO(world))));
     }
 
     @DeleteMapping("")
     public ResponseEntity<?> removeWorld(@RequestParam String id) throws APIException {
-        service.delete(id);
+        worldService.delete(id);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/places")
+    public ResponseEntity<?> save(@RequestBody PlaceRQDTO place) throws APIException {
+        return ResponseEntity.ok(placeMapper.toRSDTO(placeService.save(placeMapper.toIDTO(place))));
+    }
+
+    @DeleteMapping("/places")
+    public ResponseEntity<?> remove(@RequestParam String id) throws APIException {
+        placeService.delete(id);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/achievements/AchievementRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/achievements/AchievementRQDTO.java
@@ -1,9 +1,9 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.achievements;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementOrigin;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementTier;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 
 import java.util.Map;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/achievements/AchievementRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/achievements/AchievementRQDTO.java
@@ -5,37 +5,11 @@ import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementOrigin;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementTier;
 
-import java.util.Map;
-
 @Builder
 public record AchievementRQDTO(
-    String identifier,
     TranslatedString name,
     TranslatedString description,
     String image,
     AchievementTier tier,
     AchievementOrigin origin
-) {
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"image\": \"" + image + "\"," +
-                "\"tier\": \"" + tier + "\"" +
-                "\"origin\": \"" + origin + "\"" +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        return Map.of(
-            "identifier", identifier,
-            "name", name,
-            "description", description,
-            "image", image,
-            "tier", tier,
-            "origin", origin
-        );
-    }
-}
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/characters/CharacterRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/characters/CharacterRQDTO.java
@@ -5,7 +5,6 @@ import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CharacterRQDTO(
-        String identifier,
         TranslatedString name,
         TranslatedString title,
         TranslatedString description,

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/characters/CharacterRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/characters/CharacterRQDTO.java
@@ -1,11 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.characters;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.WorldRQDTO;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
-
-import java.util.HashMap;
-import java.util.Map;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 @Builder
 public record CharacterRQDTO(
@@ -13,36 +9,8 @@ public record CharacterRQDTO(
         TranslatedString name,
         TranslatedString title,
         TranslatedString description,
-        WorldRQDTO world,
+        String world,
         Boolean inGame,
         String image,
         TranslatedString race
-) {
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"title\": \"" + title + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"world\": \"" + world.identifier() + "\"," +
-                "\"race\": \"" + race + "\"," +
-                "\"image\": \"" + image + "\"" +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        final var map = new HashMap<String, Object>(Map.of(
-                "identifier", identifier,
-                "name", name,
-                "title", title,
-                "description", description,
-                "world", world != null ? world.identifier() : "null",
-                "race", race,
-                "image", image
-        ));
-
-        return map;
-    }
-}
-
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/creatures/CreatureRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/creatures/CreatureRQDTO.java
@@ -3,33 +3,10 @@ package org.gycoding.fallofthegods.infrastructure.api.dto.in.creatures;
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
-import java.util.Map;
-
 @Builder
 public record CreatureRQDTO(
-        String identifier,
         TranslatedString name,
         TranslatedString description,
         Boolean inGame,
         String image
-) {
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"image\": \"" + image + "\"" +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        return new java.util.HashMap<>(Map.of(
-                "identifier", identifier,
-                "name", name,
-                "description", description,
-                "image", image
-        ));
-    }
-}
-
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/creatures/CreatureRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/creatures/CreatureRQDTO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.creatures;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.Map;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
@@ -1,9 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.items;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
-import org.gycoding.fallofthegods.infrastructure.api.dto.in.StatRQDTO;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
@@ -5,38 +5,13 @@ import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 
 import java.util.List;
-import java.util.Map;
 
 @Builder
 public record ItemRQDTO(
-        String identifier,
         TranslatedString name,
         TranslatedString description,
         String image,
         Boolean inGame,
         ItemType type,
         List<ItemRQDTO> fragments
-) {
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"image\": \"" + image + "\"," +
-                "\"type\": \"" + type + "\"," +
-                "\"fragments\": \"" + fragments +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        return Map.of(
-                "identifier", identifier,
-                "name", name,
-                "description", description,
-                "image", image,
-                "type", type,
-                "fragments", fragments
-        );
-    }
-}
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/items/ItemRQDTO.java
@@ -4,14 +4,11 @@ import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 
-import java.util.List;
-
 @Builder
 public record ItemRQDTO(
         TranslatedString name,
         TranslatedString description,
         String image,
         Boolean inGame,
-        ItemType type,
-        List<ItemRQDTO> fragments
+        ItemType type
 ) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/PlaceRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/PlaceRQDTO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.Map;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/PlaceRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/PlaceRQDTO.java
@@ -3,32 +3,10 @@ package org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds;
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
-import java.util.Map;
-
 @Builder
 public record PlaceRQDTO(
-        String identifier,
         TranslatedString name,
         TranslatedString description,
         String image,
         Boolean inGame
-) {
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"image\": \"" + image + "\"" +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        return Map.of(
-                "identifier", identifier,
-                "name", name,
-                "description", description,
-                "image", image
-        );
-    }
-}
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/WorldRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/WorldRQDTO.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/WorldRQDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/in/worlds/WorldRQDTO.java
@@ -4,76 +4,13 @@ import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 
 import java.util.List;
-import java.util.Map;
 
 @Builder
 public record WorldRQDTO(
-        String identifier,
         TranslatedString name,
         TranslatedString description,
         String image,
         String detailedIcon,
         String mainColor,
-        List<PlaceRQDTO> places
-) {
-    public List<PlaceRQDTO> listPlaces() {
-        return places;
-    }
-
-    public PlaceRQDTO getPlace(String id) {
-        PlaceRQDTO placeFound = null;
-
-        for(PlaceRQDTO place : places) {
-            if(place.identifier().equals(id)) {
-                placeFound = place;
-                break;
-            }
-        }
-
-        return placeFound;
-    }
-
-    public void addPlace(PlaceRQDTO place) {
-        this.places.add(place);
-    }
-
-    public void removePlace(String id) {
-        PlaceRQDTO placeFound = null;
-
-        for(PlaceRQDTO place : places) {
-            if(place.identifier().equals(id)) {
-                placeFound = place;
-                break;
-            }
-        }
-
-        if(placeFound != null) {
-            this.places.remove(placeFound);
-        }
-    }
-
-    @Override
-    public String toString() {
-        return "{" +
-                "\"identifier\": \"" + identifier + "\"," +
-                "\"name\": \"" + name + "\"," +
-                "\"description\": \"" + description + "\"," +
-                "\"image\": \"" + image + "\"," +
-                "\"detailedIcon\": \"" + detailedIcon + "\"," +
-                "\"mainColor\": \"" + mainColor + "\"," +
-                "\"places\": " + places.toString() +
-                "}";
-    }
-
-    public Map<String, Object> toMap() {
-        return Map.of(
-                "identifier", identifier,
-                "name", name,
-                "description", description,
-                "image", detailedIcon,
-                "detailedIcon", detailedIcon,
-                "mainColor", mainColor,
-                "places", places
-        );
-    }
-}
+        List<String> places
+) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/out/items/ItemRSDTO.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/dto/out/items/ItemRSDTO.java
@@ -3,14 +3,11 @@ package org.gycoding.fallofthegods.infrastructure.api.dto.out.items;
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 
-import java.util.List;
-
 @Builder
 public record ItemRSDTO(
         String identifier,
         String name,
         String description,
         String image,
-        ItemType type,
-        List<ItemRSDTO> fragments
+        ItemType type
 ) { }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/AchievementControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/AchievementControllerMapper.java
@@ -4,10 +4,13 @@ import org.gycoding.fallofthegods.application.dto.in.achievements.AchievementIDT
 import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.achievements.AchievementRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.achievements.AchievementRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface AchievementControllerMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(achievement.name().en()))")
     AchievementIDTO toIDTO(AchievementRQDTO achievement);
 
     AchievementRSDTO toRSDTO(AchievementODTO achievement);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/AchievementControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/AchievementControllerMapper.java
@@ -13,5 +13,8 @@ public interface AchievementControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(achievement.name().en()))")
     AchievementIDTO toIDTO(AchievementRQDTO achievement);
 
+    @Mapping(target = "identifier", source = "identifier")
+    AchievementIDTO toIDTO(AchievementRQDTO achievement, String identifier);
+
     AchievementRSDTO toRSDTO(AchievementODTO achievement);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CharacterControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CharacterControllerMapper.java
@@ -4,11 +4,13 @@ import org.gycoding.fallofthegods.application.dto.in.characters.CharacterIDTO;
 import org.gycoding.fallofthegods.application.dto.out.characters.CharacterODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.characters.CharacterRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.characters.CharacterRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface CharacterControllerMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(character.name().en()))")
     CharacterIDTO toIDTO(CharacterRQDTO character);
 
     CharacterRSDTO toRSDTO(CharacterODTO character);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CharacterControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CharacterControllerMapper.java
@@ -13,5 +13,8 @@ public interface CharacterControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(character.name().en()))")
     CharacterIDTO toIDTO(CharacterRQDTO character);
 
+    @Mapping(target = "identifier", source = "identifier")
+    CharacterIDTO toIDTO(CharacterRQDTO character, String identifier);
+
     CharacterRSDTO toRSDTO(CharacterODTO character);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CreatureControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CreatureControllerMapper.java
@@ -4,10 +4,13 @@ import org.gycoding.fallofthegods.application.dto.in.creatures.CreatureIDTO;
 import org.gycoding.fallofthegods.application.dto.out.creatures.CreatureODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.creatures.CreatureRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.creatures.CreatureRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface CreatureControllerMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(creature.name().en()))")
     CreatureIDTO toIDTO(CreatureRQDTO creature);
 
     CreatureRSDTO toRSDTO(CreatureODTO creature);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CreatureControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/CreatureControllerMapper.java
@@ -13,5 +13,8 @@ public interface CreatureControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(creature.name().en()))")
     CreatureIDTO toIDTO(CreatureRQDTO creature);
 
+    @Mapping(target = "identifier", source = "identifier")
+    CreatureIDTO toIDTO(CreatureRQDTO creature, String identifier);
+
     CreatureRSDTO toRSDTO(CreatureODTO creature);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/ItemControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/ItemControllerMapper.java
@@ -4,13 +4,13 @@ import org.gycoding.fallofthegods.application.dto.in.items.ItemIDTO;
 import org.gycoding.fallofthegods.application.dto.out.items.ItemODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.items.ItemRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.items.ItemRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.List;
-
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface ItemControllerMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(item.name().en()))")
     ItemIDTO toIDTO(ItemRQDTO item);
 
     ItemRSDTO toRSDTO(ItemODTO item);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/ItemControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/ItemControllerMapper.java
@@ -13,5 +13,8 @@ public interface ItemControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(item.name().en()))")
     ItemIDTO toIDTO(ItemRQDTO item);
 
+    @Mapping(target = "identifier", source = "identifier")
+    ItemIDTO toIDTO(ItemRQDTO item, String identifier);
+
     ItemRSDTO toRSDTO(ItemODTO item);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/PlaceControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/PlaceControllerMapper.java
@@ -13,5 +13,8 @@ public interface PlaceControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(place.name().en()))")
     PlaceIDTO toIDTO(PlaceRQDTO place);
 
+    @Mapping(target = "identifier", source = "identifier")
+    PlaceIDTO toIDTO(PlaceRQDTO place, String identifier);
+
     PlaceRSDTO toRSDTO(PlaceODTO place);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/PlaceControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/PlaceControllerMapper.java
@@ -4,10 +4,13 @@ import org.gycoding.fallofthegods.application.dto.in.worlds.PlaceIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.PlaceODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.PlaceRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.worlds.PlaceRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface PlaceControllerMapper {
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(place.name().en()))")
     PlaceIDTO toIDTO(PlaceRQDTO place);
 
     PlaceRSDTO toRSDTO(PlaceODTO place);

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/WorldControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/WorldControllerMapper.java
@@ -13,5 +13,8 @@ public interface WorldControllerMapper {
     @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(world.name().en()))")
     WorldIDTO toIDTO(WorldRQDTO world);
 
+    @Mapping(target = "identifier", source = "identifier")
+    WorldIDTO toIDTO(WorldRQDTO world, String identifier);
+
     WorldRSDTO toRSDTO(WorldODTO world);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/WorldControllerMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/api/mapper/WorldControllerMapper.java
@@ -4,11 +4,14 @@ import org.gycoding.fallofthegods.application.dto.in.worlds.WorldIDTO;
 import org.gycoding.fallofthegods.application.dto.out.worlds.WorldODTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.in.worlds.WorldRQDTO;
 import org.gycoding.fallofthegods.infrastructure.api.dto.out.worlds.WorldRSDTO;
+import org.gycoding.fallofthegods.shared.IdentifierGenerator;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = { IdentifierGenerator.class })
 public interface WorldControllerMapper {
-    WorldIDTO toIDTO(WorldRQDTO place);
+    @Mapping(target = "identifier", expression = "java(IdentifierGenerator.generate(world.name().en()))")
+    WorldIDTO toIDTO(WorldRQDTO world);
 
-    WorldRSDTO toRSDTO(WorldODTO place);
+    WorldRSDTO toRSDTO(WorldODTO world);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/AchievementDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/AchievementDatabaseMapper.java
@@ -1,12 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
-import org.gycoding.fallofthegods.application.dto.out.achievements.AchievementODTO;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.achievements.AchievementEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface AchievementDatabaseMapper {

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/AchievementDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/AchievementDatabaseMapper.java
@@ -2,11 +2,17 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.achievements.AchievementEntity;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface AchievementDatabaseMapper {
     AchievementMO toMO(AchievementEntity achievement);
 
     AchievementEntity toEntity(AchievementMO achievement);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    AchievementEntity toUpdatedEntity(@MappingTarget AchievementEntity persistedAchievement, AchievementMO achievement);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CharacterDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CharacterDatabaseMapper.java
@@ -2,11 +2,19 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.characters.CharacterEntity;
+import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CharacterDatabaseMapper {
+    @Mapping(target = "world", source = "world.identifier")
     CharacterMO toMO(CharacterEntity character);
 
-    CharacterEntity toEntity(CharacterMO character);
+    @Mapping(target = "world", source = "persistedWorld")
+    @Mapping(target = "identifier", source = "character.identifier")
+    @Mapping(target = "name", source = "character.name")
+    @Mapping(target = "description", source = "character.description")
+    @Mapping(target = "image", source = "character.image")
+    CharacterEntity toEntity(CharacterMO character, WorldEntity persistedWorld);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CharacterDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CharacterDatabaseMapper.java
@@ -3,8 +3,7 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 import org.gycoding.fallofthegods.domain.model.characters.CharacterMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.characters.CharacterEntity;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 
 @Mapper(componentModel = "spring")
 public interface CharacterDatabaseMapper {
@@ -17,4 +16,12 @@ public interface CharacterDatabaseMapper {
     @Mapping(target = "description", source = "character.description")
     @Mapping(target = "image", source = "character.image")
     CharacterEntity toEntity(CharacterMO character, WorldEntity persistedWorld);
+
+    @Mapping(target = "world", source = "persistedWorld")
+    @Mapping(target = "identifier", source = "character.identifier")
+    @Mapping(target = "name", source = "character.name")
+    @Mapping(target = "description", source = "character.description")
+    @Mapping(target = "image", source = "character.image")
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    CharacterEntity toUpdatedEntity(@MappingTarget CharacterEntity persistedCharacter, CharacterMO character, WorldEntity persistedWorld);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CreatureDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/CreatureDatabaseMapper.java
@@ -2,11 +2,17 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.creatures.CreatureEntity;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface CreatureDatabaseMapper {
     CreatureMO toMO(CreatureEntity creature);
 
     CreatureEntity toEntity(CreatureMO creature);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    CreatureEntity toUpdatedEntity(@MappingTarget CreatureEntity persistedCreature, CreatureMO creature);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/ItemDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/ItemDatabaseMapper.java
@@ -2,11 +2,17 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.items.ItemEntity;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface ItemDatabaseMapper {
     ItemMO toMO(ItemEntity item);
 
     ItemEntity toEntity(ItemMO item);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    ItemEntity toUpdatedEntity(@MappingTarget ItemEntity persistedItem, ItemMO item);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/PlaceDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/PlaceDatabaseMapper.java
@@ -2,11 +2,17 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.PlaceEntity;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring")
 public interface PlaceDatabaseMapper {
     PlaceMO toMO(PlaceEntity place);
 
     PlaceEntity toEntity(PlaceMO place);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    PlaceEntity toUpdatedEntity(@MappingTarget PlaceEntity persistedPlace, PlaceMO place);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/WorldDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/WorldDatabaseMapper.java
@@ -1,12 +1,21 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 
 import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
+import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.PlaceEntity;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface WorldDatabaseMapper {
     WorldMO toMO(WorldEntity world);
 
-    WorldEntity toEntity(WorldMO world);
+    @Mapping(target = "places", source = "persistedPlaces")
+    @Mapping(target = "identifier", source = "world.identifier")
+    @Mapping(target = "name", source = "world.name")
+    @Mapping(target = "description", source = "world.description")
+    @Mapping(target = "image", source = "world.image")
+    WorldEntity toEntity(WorldMO world, List<PlaceEntity> persistedPlaces);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/WorldDatabaseMapper.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/mapper/WorldDatabaseMapper.java
@@ -3,8 +3,7 @@ package org.gycoding.fallofthegods.infrastructure.external.database.mapper;
 import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.PlaceEntity;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 
 import java.util.List;
 
@@ -18,4 +17,12 @@ public interface WorldDatabaseMapper {
     @Mapping(target = "description", source = "world.description")
     @Mapping(target = "image", source = "world.image")
     WorldEntity toEntity(WorldMO world, List<PlaceEntity> persistedPlaces);
+
+    @Mapping(target = "places", source = "persistedPlaces")
+    @Mapping(target = "identifier", source = "world.identifier")
+    @Mapping(target = "name", source = "world.name")
+    @Mapping(target = "description", source = "world.description")
+    @Mapping(target = "image", source = "world.image")
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    WorldEntity toUpdatedEntity(@MappingTarget WorldEntity persistedWorld, WorldMO world, List<PlaceEntity> persistedPlaces);
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/achievements/AchievementEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/achievements/AchievementEntity.java
@@ -1,21 +1,35 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.achievements;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementOrigin;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementTier;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "Achievement")
-public record AchievementEntity(
+public class AchievementEntity {
     @Id
-    String mongoId,
-    String identifier,
-    TranslatedString name,
-    TranslatedString description,
-    String image,
-    AchievementTier tier,
-    AchievementOrigin origin
-) {}
+    public String mongoId;
+    public String identifier;
+    public TranslatedString name;
+    public TranslatedString description;
+    public String image;
+    public AchievementTier tier;
+    public AchievementOrigin origin;
+
+    @Builder
+    public AchievementEntity(String mongoId, String identifier, TranslatedString name, TranslatedString description, String image, AchievementTier tier, AchievementOrigin origin) {
+        this.mongoId = mongoId;
+        this.identifier = identifier;
+        this.name = name;
+        this.description = description;
+        this.image = image;
+        this.tier = tier;
+        this.origin = origin;
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/achievements/AchievementEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/achievements/AchievementEntity.java
@@ -1,9 +1,9 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.achievements;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementOrigin;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementTier;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/characters/CharacterEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/characters/CharacterEntity.java
@@ -1,9 +1,10 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.characters;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Builder
@@ -15,6 +16,7 @@ public record CharacterEntity(
         TranslatedString name,
         TranslatedString title,
         TranslatedString description,
+        @DBRef
         WorldEntity world,
         Boolean inGame,
         String image,

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/characters/CharacterEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/characters/CharacterEntity.java
@@ -1,25 +1,40 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.characters;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "Character")
-public record CharacterEntity(
+public class CharacterEntity {
         @Id
-        String mongoId,
-        String identifier,
-        TranslatedString name,
-        TranslatedString title,
-        TranslatedString description,
+        public String mongoId;
+        public String identifier;
+        public TranslatedString name;
+        public TranslatedString title;
+        public TranslatedString description;
         @DBRef
-        WorldEntity world,
-        Boolean inGame,
-        String image,
-        TranslatedString race
-) {}
+        public WorldEntity world;
+        public Boolean inGame;
+        public String image;
+        public TranslatedString race;
 
+        @Builder
+        public CharacterEntity(String mongoId, String identifier, TranslatedString name, TranslatedString title, TranslatedString description, WorldEntity world, Boolean inGame, String image, TranslatedString race) {
+                this.mongoId = mongoId;
+                this.identifier = identifier;
+                this.name = name;
+                this.title = title;
+                this.description = description;
+                this.world = world;
+                this.inGame = inGame;
+                this.image = image;
+                this.race = race;
+        }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/creatures/CreatureEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/creatures/CreatureEntity.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.creatures;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/creatures/CreatureEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/creatures/CreatureEntity.java
@@ -1,19 +1,31 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.creatures;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "Creature")
-public record CreatureEntity(
+public class CreatureEntity {
         @Id
-        String mongoId,
-        String identifier,
-        TranslatedString name,
-        TranslatedString description,
-        Boolean inGame,
-        String image
-) {}
+        public String mongoId;
+        public String identifier;
+        public TranslatedString name;
+        public TranslatedString description;
+        public Boolean inGame;
+        public String image;
 
+        @Builder
+        public CreatureEntity(String mongoId, String identifier, TranslatedString name, TranslatedString description, Boolean inGame, String image) {
+            this.mongoId = mongoId;
+            this.identifier = identifier;
+            this.name = name;
+            this.description = description;
+            this.inGame = inGame;
+            this.image = image;
+        }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
@@ -1,8 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.items;
 
 import lombok.Builder;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
@@ -6,8 +6,6 @@ import org.gycoding.fallofthegods.domain.model.items.ItemType;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.List;
-
 @Builder
 @Document(collection = "Item")
 public record ItemEntity(
@@ -18,6 +16,5 @@ public record ItemEntity(
     TranslatedString description,
     String image,
     Boolean inGame,
-    ItemType type,
-    List<ItemEntity> fragments
+    ItemType type
 ) {}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/items/ItemEntity.java
@@ -1,20 +1,34 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.items;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.gycoding.fallofthegods.domain.model.items.ItemType;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "Item")
-public record ItemEntity(
+public class ItemEntity {
     @Id
-    String mongoId,
-    String identifier,
-    TranslatedString name,
-    TranslatedString description,
-    String image,
-    Boolean inGame,
-    ItemType type
-) {}
+    public String mongoId;
+    public String identifier;
+    public TranslatedString name;
+    public TranslatedString description;
+    public String image;
+    public Boolean inGame;
+    public ItemType type;
+
+    @Builder
+    public ItemEntity(String mongoId, String identifier, TranslatedString name, TranslatedString description, String image, Boolean inGame, ItemType type) {
+        this.mongoId = mongoId;
+        this.identifier = identifier;
+        this.name = name;
+        this.description = description;
+        this.image = image;
+        this.inGame = inGame;
+        this.type = type;
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/PlaceEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/PlaceEntity.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/PlaceEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/PlaceEntity.java
@@ -1,18 +1,31 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.worlds;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "Place")
-public record PlaceEntity(
+public class PlaceEntity {
         @Id
-        String mongoId,
-        String identifier,
-        TranslatedString name,
-        TranslatedString description,
-        String image,
-        Boolean inGame
-) {}
+        public String mongoId;
+        public String identifier;
+        public TranslatedString name;
+        public TranslatedString description;
+        public String image;
+        public Boolean inGame;
+
+        @Builder
+        public PlaceEntity(String mongoId, String identifier, TranslatedString name, TranslatedString description, String image, Boolean inGame) {
+            this.mongoId = mongoId;
+            this.identifier = identifier;
+            this.name = name;
+            this.description = description;
+            this.image = image;
+            this.inGame = inGame;
+        }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.worlds;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
@@ -8,17 +10,30 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
 
-@Builder
+@Getter
+@Setter
 @Document(collection = "World")
-public record WorldEntity(
+public class WorldEntity {
         @Id
-        String mongoId,
-        String identifier,
-        TranslatedString name,
-        TranslatedString description,
-        String image,
-        String detailedIcon,
-        String mainColor,
+        public String mongoId;
+        public String identifier;
+        public TranslatedString name;
+        public TranslatedString description;
+        public String image;
+        public String detailedIcon;
+        public String mainColor;
         @DBRef
-        List<PlaceEntity> places
-) {}
+        public List<PlaceEntity> places;
+
+        @Builder
+        public WorldEntity(String mongoId, String identifier, TranslatedString name, TranslatedString description, String image, String detailedIcon, String mainColor, List<PlaceEntity> places) {
+            this.mongoId = mongoId;
+            this.identifier = identifier;
+            this.name = name;
+            this.description = description;
+            this.image = image;
+            this.detailedIcon = detailedIcon;
+            this.mainColor = mainColor;
+            this.places = places;
+        }
+}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
@@ -1,7 +1,7 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.model.worlds;
 
 import lombok.Builder;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/model/worlds/WorldEntity.java
@@ -3,6 +3,7 @@ package org.gycoding.fallofthegods.infrastructure.external.database.model.worlds
 import lombok.Builder;
 import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
@@ -18,5 +19,6 @@ public record WorldEntity(
         String image,
         String detailedIcon,
         String mainColor,
+        @DBRef
         List<PlaceEntity> places
 ) {}

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/AchievementRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/AchievementRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.gycoding.fallofthegods.domain.repository.AchievementRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.AchievementDatabaseMapper;
@@ -23,6 +25,19 @@ public class AchievementRepositoryImpl implements AchievementRepository {
     @Override
     public AchievementMO save(AchievementMO achievement) {
         return mapper.toMO(repository.save(mapper.toEntity(achievement)));
+    }
+
+    @Override
+    public AchievementMO update(AchievementMO achievement) throws APIException {
+        final var persistedAchievement = repository.findByIdentifier(achievement.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                )
+        );
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedAchievement, achievement)));
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/AchievementRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/AchievementRepositoryImpl.java
@@ -1,12 +1,9 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.achievements.AchievementMO;
 import org.gycoding.fallofthegods.domain.repository.AchievementRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.AchievementDatabaseMapper;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.achievements.AchievementEntity;
 import org.gycoding.fallofthegods.infrastructure.external.database.repository.AchievementMongoRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -24,75 +21,35 @@ public class AchievementRepositoryImpl implements AchievementRepository {
     private final AchievementDatabaseMapper mapper;
 
     @Override
-    public AchievementMO save(AchievementMO achievement) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(achievement)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public AchievementMO save(AchievementMO achievement) {
+        return mapper.toMO(repository.save(mapper.toEntity(achievement)));
     }
 
     @Override
-    public Optional<AchievementMO> get(String identifier) throws APIException {
-        final var achievementEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
+    }
+
+    @Override
+    public Optional<AchievementMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    @Override
+    public List<AchievementMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public Page<AchievementMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
         );
-
-        return Optional.of(mapper.toMO(achievementEntity));
-    }
-
-    @Override
-    public List<AchievementMO> list() throws APIException {
-        List<AchievementEntity> achievementEntities;
-
-        try {
-            achievementEntities = repository.findAll();
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return achievementEntities.stream().map(mapper::toMO).toList();
-    }
-
-    @Override
-    public Page<AchievementMO> page(Pageable pageable) throws APIException {
-        Page<AchievementEntity> achievementEntities;
-
-        try {
-            achievementEntities = repository.findAll(pageable);
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(achievementEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
@@ -50,6 +50,7 @@ public class CharacterRepositoryImpl implements CharacterRepository {
                 .map(mapper::toMO);
     }
 
+    @Override
     public Optional<CharacterMO> get(String identifier, Boolean inGame) {
         Optional<CharacterEntity> characterEntity;
 
@@ -62,12 +63,14 @@ public class CharacterRepositoryImpl implements CharacterRepository {
         return characterEntity.map(mapper::toMO);
     }
 
+    @Override
     public List<CharacterMO> list() {
         return repository.findAll().stream()
                 .map(mapper::toMO)
                 .toList();
     }
 
+    @Override
     public List<CharacterMO> list(Boolean inGame) {
         List<CharacterEntity> characterEntities;
 
@@ -82,6 +85,7 @@ public class CharacterRepositoryImpl implements CharacterRepository {
                 .toList();
     }
 
+    @Override
     public Page<CharacterMO> page(Pageable pageable) {
         return PagingConverter.listToPage(
                 repository.findAll(pageable).stream()
@@ -91,6 +95,7 @@ public class CharacterRepositoryImpl implements CharacterRepository {
         );
     }
 
+    @Override
     public Page<CharacterMO> page(Pageable pageable, Boolean inGame) {
         Page<CharacterEntity> characterEntities;
 

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
@@ -40,6 +40,21 @@ public class CharacterRepositoryImpl implements CharacterRepository {
     }
 
     @Override
+    public CharacterMO update(CharacterMO character) throws APIException {
+        final var persistedCharacter = repository.findByIdentifier(character.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                )
+        );
+
+        final var persistedWorld = worldRepository.findByIdentifier(character.world()).orElse(null);
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedCharacter, character, persistedWorld)));
+    }
+
+    @Override
     public void delete(String identifier) {
         repository.removeByIdentifier(identifier);
     }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
@@ -40,6 +40,11 @@ public class CharacterRepositoryImpl implements CharacterRepository {
     }
 
     @Override
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
+    }
+
+    @Override
     public Optional<CharacterMO> get(String identifier) {
         return repository.findByIdentifier(identifier)
                 .map(mapper::toMO);
@@ -101,10 +106,5 @@ public class CharacterRepositoryImpl implements CharacterRepository {
                         .toList(),
                 pageable
         );
-    }
-
-    @Override
-    public void delete(String identifier) {
-        repository.removeByIdentifier(identifier);
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CharacterRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.gycoding.fallofthegods.domain.repository.CharacterRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.CharacterDatabaseMapper;
 import org.gycoding.fallofthegods.infrastructure.external.database.model.characters.CharacterEntity;
 import org.gycoding.fallofthegods.infrastructure.external.database.repository.CharacterMongoRepository;
+import org.gycoding.fallofthegods.infrastructure.external.database.repository.WorldMongoRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,22 +24,11 @@ public class CharacterRepositoryImpl implements CharacterRepository {
 
     private final CharacterDatabaseMapper mapper;
 
-    @Override
-    public CharacterMO save(CharacterMO character) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(character)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
-    }
+    private final WorldMongoRepository worldRepository;
 
     @Override
-    public Optional<CharacterMO> get(String identifier) throws APIException {
-        final var characterEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
+    public CharacterMO save(CharacterMO character) throws APIException {
+        final var persistedWorld = worldRepository.findByIdentifier(character.world()).orElseThrow(() ->
                 new APIException(
                         FOTGAPIError.RESOURCE_NOT_FOUND.code,
                         FOTGAPIError.RESOURCE_NOT_FOUND.message,
@@ -46,10 +36,16 @@ public class CharacterRepositoryImpl implements CharacterRepository {
                 )
         );
 
-        return Optional.of(mapper.toMO(characterEntity));
+        return mapper.toMO(repository.save(mapper.toEntity(character, persistedWorld)));
     }
 
-    public Optional<CharacterMO> get(String identifier, Boolean inGame) throws APIException {
+    @Override
+    public Optional<CharacterMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    public Optional<CharacterMO> get(String identifier, Boolean inGame) {
         Optional<CharacterEntity> characterEntity;
 
         if(inGame) {
@@ -58,99 +54,57 @@ public class CharacterRepositoryImpl implements CharacterRepository {
             characterEntity = repository.findByIdentifier(identifier);
         }
 
-        characterEntity.orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(characterEntity.get()));
+        return characterEntity.map(mapper::toMO);
     }
 
-    public List<CharacterMO> list() throws APIException {
+    public List<CharacterMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    public List<CharacterMO> list(Boolean inGame) {
         List<CharacterEntity> characterEntities;
 
-        try {
+        if(inGame) {
+            characterEntities = repository.findByInGame(inGame);
+        } else {
             characterEntities = repository.findAll();
-        } catch(NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
         }
 
-        return characterEntities.stream().map(mapper::toMO).toList();
+        return characterEntities.stream()
+                .map(mapper::toMO)
+                .toList();
     }
 
-    public List<CharacterMO> list(Boolean inGame) throws APIException {
-        List<CharacterEntity> characterEntities;
-
-        try {
-            if(inGame) {
-                characterEntities = repository.findByInGame(inGame);
-            } else {
-                characterEntities = repository.findAll();
-            }
-        } catch(NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return characterEntities.stream().map(mapper::toMO).toList();
+    public Page<CharacterMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                    .map(mapper::toMO)
+                    .toList(),
+                pageable
+        );
     }
 
-    public Page<CharacterMO> page(Pageable pageable) throws APIException {
+    public Page<CharacterMO> page(Pageable pageable, Boolean inGame) {
         Page<CharacterEntity> characterEntities;
 
-        try {
+        if(inGame) {
+            characterEntities = repository.findByInGame(inGame, pageable);
+        } else {
             characterEntities = repository.findAll(pageable);
-        } catch(NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
         }
 
-        return PagingConverter.listToPage(characterEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    public Page<CharacterMO> page(Pageable pageable, Boolean inGame) throws APIException {
-        Page<CharacterEntity> characterEntities;
-
-        try {
-            if(inGame) {
-                characterEntities = repository.findByInGame(inGame, pageable);
-            } else {
-                characterEntities = repository.findAll(pageable);
-            }
-        } catch(NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(characterEntities.stream().map(mapper::toMO).toList(), pageable);
+        return PagingConverter.listToPage(
+                characterEntities.stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
     }
 
     @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CreatureRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CreatureRepositoryImpl.java
@@ -1,8 +1,6 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.gycoding.fallofthegods.domain.repository.CreatureRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.CreatureDatabaseMapper;
@@ -24,133 +22,81 @@ public class CreatureRepositoryImpl implements CreatureRepository {
     private final CreatureDatabaseMapper mapper;
 
     @Override
-    public CreatureMO save(CreatureMO creature) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(creature)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public CreatureMO save(CreatureMO creature) {
+        return mapper.toMO(repository.save(mapper.toEntity(creature)));
     }
 
     @Override
-    public Optional<CreatureMO> get(String identifier) throws APIException {
-        final var creatureEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(creatureEntity));
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
     }
 
-    public Optional<CreatureMO> get(String identifier, Boolean inGame) throws APIException {
+    @Override
+    public Optional<CreatureMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    @Override
+    public Optional<CreatureMO> get(String identifier, Boolean inGame) {
         Optional<CreatureEntity> creatureEntity;
 
-        if (inGame) {
+        if(inGame) {
             creatureEntity = repository.findByIdentifierAndInGame(identifier, inGame);
         } else {
             creatureEntity = repository.findByIdentifier(identifier);
         }
 
-        creatureEntity.orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(creatureEntity.get()));
-    }
-
-    public List<CreatureMO> list() throws APIException {
-        List<CreatureEntity> creatureEntities;
-
-        try {
-            creatureEntities = repository.findAll();
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return creatureEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public List<CreatureMO> list(Boolean inGame) throws APIException {
-        List<CreatureEntity> creatureEntities;
-
-        try {
-            if (inGame) {
-                creatureEntities = repository.findByInGame(inGame);
-            } else {
-                creatureEntities = repository.findAll();
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return creatureEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public Page<CreatureMO> page(Pageable pageable) throws APIException {
-        Page<CreatureEntity> creatureEntities;
-
-        try {
-            creatureEntities = repository.findAll(pageable);
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(creatureEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    public Page<CreatureMO> page(Pageable pageable, Boolean inGame) throws APIException {
-        Page<CreatureEntity> creatureEntities;
-
-        try {
-            if (inGame) {
-                creatureEntities = repository.findByInGame(inGame, pageable);
-            } else {
-                creatureEntities = repository.findAll(pageable);
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(creatureEntities.stream().map(mapper::toMO).toList(), pageable);
+        return creatureEntity.map(mapper::toMO);
     }
 
     @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
+    public List<CreatureMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public List<CreatureMO> list(Boolean inGame) {
+        List<CreatureEntity> creatureEntities;
+
+        if(inGame) {
+            creatureEntities = repository.findByInGame(inGame);
+        } else {
+            creatureEntities = repository.findAll();
         }
+
+        return creatureEntities.stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public Page<CreatureMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
+    }
+
+    @Override
+    public Page<CreatureMO> page(Pageable pageable, Boolean inGame) {
+        Page<CreatureEntity> creatureEntities;
+
+        if(inGame) {
+            creatureEntities = repository.findByInGame(inGame, pageable);
+        } else {
+            creatureEntities = repository.findAll(pageable);
+        }
+
+        return PagingConverter.listToPage(
+                creatureEntities.stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CreatureRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/CreatureRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.creatures.CreatureMO;
 import org.gycoding.fallofthegods.domain.repository.CreatureRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.CreatureDatabaseMapper;
@@ -24,6 +26,19 @@ public class CreatureRepositoryImpl implements CreatureRepository {
     @Override
     public CreatureMO save(CreatureMO creature) {
         return mapper.toMO(repository.save(mapper.toEntity(creature)));
+    }
+
+    @Override
+    public CreatureMO update(CreatureMO creature) throws APIException {
+        final var persistedCreature = repository.findByIdentifier(creature.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                )
+        );
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedCreature, creature)));
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/ItemRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/ItemRepositoryImpl.java
@@ -1,8 +1,6 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.gycoding.fallofthegods.domain.repository.ItemRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.ItemDatabaseMapper;
@@ -24,133 +22,81 @@ public class ItemRepositoryImpl implements ItemRepository {
     private final ItemDatabaseMapper mapper;
 
     @Override
-    public ItemMO save(ItemMO item) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(item)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public ItemMO save(ItemMO item) {
+        return mapper.toMO(repository.save(mapper.toEntity(item)));
     }
 
     @Override
-    public Optional<ItemMO> get(String identifier) throws APIException {
-        final var itemEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(itemEntity));
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
     }
 
-    public Optional<ItemMO> get(String identifier, Boolean inGame) throws APIException {
+    @Override
+    public Optional<ItemMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    @Override
+    public Optional<ItemMO> get(String identifier, Boolean inGame) {
         Optional<ItemEntity> itemEntity;
 
-        if (inGame) {
+        if(inGame) {
             itemEntity = repository.findByIdentifierAndInGame(identifier, inGame);
         } else {
             itemEntity = repository.findByIdentifier(identifier);
         }
 
-        itemEntity.orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(itemEntity.get()));
-    }
-
-    public List<ItemMO> list() throws APIException {
-        List<ItemEntity> itemEntities;
-
-        try {
-            itemEntities = repository.findAll();
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return itemEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public List<ItemMO> list(Boolean inGame) throws APIException {
-        List<ItemEntity> itemEntities;
-
-        try {
-            if (inGame) {
-                itemEntities = repository.findByInGame(inGame);
-            } else {
-                itemEntities = repository.findAll();
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return itemEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public Page<ItemMO> page(Pageable pageable) throws APIException {
-        Page<ItemEntity> itemEntities;
-
-        try {
-            itemEntities = repository.findAll(pageable);
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(itemEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    public Page<ItemMO> page(Pageable pageable, Boolean inGame) throws APIException {
-        Page<ItemEntity> itemEntities;
-
-        try {
-            if (inGame) {
-                itemEntities = repository.findByInGame(inGame, pageable);
-            } else {
-                itemEntities = repository.findAll(pageable);
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(itemEntities.stream().map(mapper::toMO).toList(), pageable);
+        return itemEntity.map(mapper::toMO);
     }
 
     @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
+    public List<ItemMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public List<ItemMO> list(Boolean inGame) {
+        List<ItemEntity> itemEntities;
+
+        if(inGame) {
+            itemEntities = repository.findByInGame(inGame);
+        } else {
+            itemEntities = repository.findAll();
         }
+
+        return itemEntities.stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public Page<ItemMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
+    }
+
+    @Override
+    public Page<ItemMO> page(Pageable pageable, Boolean inGame) {
+        Page<ItemEntity> itemEntities;
+
+        if(inGame) {
+            itemEntities = repository.findByInGame(inGame, pageable);
+        } else {
+            itemEntities = repository.findAll(pageable);
+        }
+
+        return PagingConverter.listToPage(
+                itemEntities.stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/ItemRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/ItemRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.items.ItemMO;
 import org.gycoding.fallofthegods.domain.repository.ItemRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.ItemDatabaseMapper;
@@ -24,6 +26,19 @@ public class ItemRepositoryImpl implements ItemRepository {
     @Override
     public ItemMO save(ItemMO item) {
         return mapper.toMO(repository.save(mapper.toEntity(item)));
+    }
+
+    @Override
+    public ItemMO update(ItemMO item) throws APIException {
+        final var persistedItem = repository.findByIdentifier(item.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                )
+        );
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedItem, item)));
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/PlaceRepositoryImpl.java
@@ -1,8 +1,6 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.gycoding.fallofthegods.domain.repository.PlaceRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.PlaceDatabaseMapper;
@@ -24,133 +22,81 @@ public class PlaceRepositoryImpl implements PlaceRepository {
     private final PlaceDatabaseMapper mapper;
 
     @Override
-    public PlaceMO save(PlaceMO place) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(place)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public PlaceMO save(PlaceMO place) {
+        return mapper.toMO(repository.save(mapper.toEntity(place)));
     }
 
     @Override
-    public Optional<PlaceMO> get(String identifier) throws APIException {
-        final var placeEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(placeEntity));
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
     }
 
-    public Optional<PlaceMO> get(String identifier, Boolean inGame) throws APIException {
+    @Override
+    public Optional<PlaceMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    @Override
+    public Optional<PlaceMO> get(String identifier, Boolean inGame) {
         Optional<PlaceEntity> placeEntity;
 
-        if (inGame) {
+        if(inGame) {
             placeEntity = repository.findByIdentifierAndInGame(identifier, inGame);
         } else {
             placeEntity = repository.findByIdentifier(identifier);
         }
 
-        placeEntity.orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
-        );
-
-        return Optional.of(mapper.toMO(placeEntity.get()));
-    }
-
-    public List<PlaceMO> list() throws APIException {
-        List<PlaceEntity> placeEntities;
-
-        try {
-            placeEntities = repository.findAll();
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return placeEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public List<PlaceMO> list(Boolean inGame) throws APIException {
-        List<PlaceEntity> placeEntities;
-
-        try {
-            if (inGame) {
-                placeEntities = repository.findByInGame(inGame);
-            } else {
-                placeEntities = repository.findAll();
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return placeEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public Page<PlaceMO> page(Pageable pageable) throws APIException {
-        Page<PlaceEntity> placeEntities;
-
-        try {
-            placeEntities = repository.findAll(pageable);
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(placeEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    public Page<PlaceMO> page(Pageable pageable, Boolean inGame) throws APIException {
-        Page<PlaceEntity> placeEntities;
-
-        try {
-            if (inGame) {
-                placeEntities = repository.findByInGame(inGame, pageable);
-            } else {
-                placeEntities = repository.findAll(pageable);
-            }
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(placeEntities.stream().map(mapper::toMO).toList(), pageable);
+        return placeEntity.map(mapper::toMO);
     }
 
     @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
+    public List<PlaceMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public List<PlaceMO> list(Boolean inGame) {
+        List<PlaceEntity> placeEntities;
+
+        if(inGame) {
+            placeEntities = repository.findByInGame(inGame);
+        } else {
+            placeEntities = repository.findAll();
         }
+
+        return placeEntities.stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public Page<PlaceMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
+    }
+
+    @Override
+    public Page<PlaceMO> page(Pageable pageable, Boolean inGame) {
+        Page<PlaceEntity> placeEntities;
+
+        if(inGame) {
+            placeEntities = repository.findByInGame(inGame, pageable);
+        } else {
+            placeEntities = repository.findAll(pageable);
+        }
+
+        return PagingConverter.listToPage(
+                placeEntities.stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
+        );
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/PlaceRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/PlaceRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.worlds.PlaceMO;
 import org.gycoding.fallofthegods.domain.repository.PlaceRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.PlaceDatabaseMapper;
@@ -24,6 +26,18 @@ public class PlaceRepositoryImpl implements PlaceRepository {
     @Override
     public PlaceMO save(PlaceMO place) {
         return mapper.toMO(repository.save(mapper.toEntity(place)));
+    }
+
+    @Override
+    public PlaceMO update(PlaceMO place) throws APIException {
+        final var persistedPlace = repository.findByIdentifier(place.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                ));
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedPlace, place)));
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/WorldRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/WorldRepositoryImpl.java
@@ -1,12 +1,10 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
-import org.gycoding.exceptions.model.APIException;
-import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
 import org.gycoding.fallofthegods.domain.repository.WorldRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.WorldDatabaseMapper;
-import org.gycoding.fallofthegods.infrastructure.external.database.model.worlds.WorldEntity;
+import org.gycoding.fallofthegods.infrastructure.external.database.repository.PlaceMongoRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.repository.WorldMongoRepository;
 import org.gycoding.fallofthegods.shared.PagingConverter;
 import org.springframework.data.domain.Page;
@@ -23,74 +21,44 @@ public class WorldRepositoryImpl implements WorldRepository {
 
     private final WorldDatabaseMapper mapper;
 
+    private final PlaceMongoRepository placeRepository;
+
     @Override
-    public WorldMO save(WorldMO world) throws APIException {
-        try {
-            return mapper.toMO(repository.save(mapper.toEntity(world)));
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
+    public WorldMO save(WorldMO world, List<String> places) {
+        final var persistedPlaces = places.stream()
+                        .map(placeRepository::findByIdentifier)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .toList();
+
+        return mapper.toMO(repository.save(mapper.toEntity(world, persistedPlaces)));
     }
 
     @Override
-    public Optional<WorldMO> get(String identifier) throws APIException {
-        final var worldEntity = repository.findByIdentifier(identifier).orElseThrow(() ->
-                new APIException(
-                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                        FOTGAPIError.RESOURCE_NOT_FOUND.status
-                )
+    public void delete(String identifier) {
+        repository.removeByIdentifier(identifier);
+    }
+
+    @Override
+    public Optional<WorldMO> get(String identifier) {
+        return repository.findByIdentifier(identifier)
+                .map(mapper::toMO);
+    }
+
+    @Override
+    public List<WorldMO> list() {
+        return repository.findAll().stream()
+                .map(mapper::toMO)
+                .toList();
+    }
+
+    @Override
+    public Page<WorldMO> page(Pageable pageable) {
+        return PagingConverter.listToPage(
+                repository.findAll(pageable).stream()
+                        .map(mapper::toMO)
+                        .toList(),
+                pageable
         );
-
-        return Optional.of(mapper.toMO(worldEntity));
-    }
-
-    public List<WorldMO> list() throws APIException {
-        List<WorldEntity> worldEntities;
-
-        try {
-            worldEntities = repository.findAll();
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return worldEntities.stream().map(mapper::toMO).toList();
-    }
-
-    public Page<WorldMO> page(Pageable pageable) throws APIException {
-        Page<WorldEntity> worldEntities;
-
-        try {
-            worldEntities = repository.findAll(pageable);
-        } catch (NullPointerException e) {
-            throw new APIException(
-                    FOTGAPIError.RESOURCE_NOT_FOUND.code,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.message,
-                    FOTGAPIError.RESOURCE_NOT_FOUND.status
-            );
-        }
-
-        return PagingConverter.listToPage(worldEntities.stream().map(mapper::toMO).toList(), pageable);
-    }
-
-    @Override
-    public void delete(String identifier) throws APIException {
-        try {
-            repository.removeByIdentifier(identifier);
-        } catch (Exception e) {
-            throw new APIException(
-                    FOTGAPIError.CONFLICT.code,
-                    FOTGAPIError.CONFLICT.message,
-                    FOTGAPIError.CONFLICT.status
-            );
-        }
     }
 }

--- a/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/WorldRepositoryImpl.java
+++ b/src/main/java/org/gycoding/fallofthegods/infrastructure/external/database/repository/impl/WorldRepositoryImpl.java
@@ -1,6 +1,8 @@
 package org.gycoding.fallofthegods.infrastructure.external.database.repository.impl;
 
 import lombok.AllArgsConstructor;
+import org.gycoding.exceptions.model.APIException;
+import org.gycoding.fallofthegods.domain.exceptions.FOTGAPIError;
 import org.gycoding.fallofthegods.domain.model.worlds.WorldMO;
 import org.gycoding.fallofthegods.domain.repository.WorldRepository;
 import org.gycoding.fallofthegods.infrastructure.external.database.mapper.WorldDatabaseMapper;
@@ -32,6 +34,25 @@ public class WorldRepositoryImpl implements WorldRepository {
                         .toList();
 
         return mapper.toMO(repository.save(mapper.toEntity(world, persistedPlaces)));
+    }
+
+    @Override
+    public WorldMO update(WorldMO world, List<String> places) throws APIException {
+        final var persistedWorlds = repository.findByIdentifier(world.identifier()).orElseThrow(() ->
+                new APIException(
+                        FOTGAPIError.RESOURCE_NOT_FOUND.code,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.message,
+                        FOTGAPIError.RESOURCE_NOT_FOUND.status
+                )
+        );
+
+        final var persistedPlaces = places.stream()
+                .map(placeRepository::findByIdentifier)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
+
+        return mapper.toMO(repository.save(mapper.toUpdatedEntity(persistedWorlds, world, persistedPlaces)));
     }
 
     @Override

--- a/src/main/java/org/gycoding/fallofthegods/shared/IdentifierGenerator.java
+++ b/src/main/java/org/gycoding/fallofthegods/shared/IdentifierGenerator.java
@@ -1,0 +1,20 @@
+package org.gycoding.fallofthegods.shared;
+
+public class IdentifierGenerator {
+    public static String generate(String name) {
+        return name.toLowerCase()
+                .replace(" ", "_")
+                .replace("ä", "a")
+                .replace("ë", "e")
+                .replace("ï", "i")
+                .replace("ö", "o")
+                .replace("ü", "u")
+                .replace("æ", "ae")
+                .replace("ø", "o")
+                .replace("á", "a")
+                .replace("é", "e")
+                .replace("í", "i")
+                .replace("ó", "o")
+                .replace("ú", "u");
+    }
+}

--- a/src/main/java/org/gycoding/fallofthegods/shared/StringTranslator.java
+++ b/src/main/java/org/gycoding/fallofthegods/shared/StringTranslator.java
@@ -1,6 +1,6 @@
 package org.gycoding.fallofthegods.shared;
 
-import org.gycoding.fallofthegods.infrastructure.external.database.model.TranslatedString;
+import org.gycoding.fallofthegods.domain.model.TranslatedString;
 import org.mapstruct.Named;
 import org.springframework.beans.factory.annotation.Qualifier;
 


### PR DESCRIPTION
This Pull Request consists of the implementation of the Management API. Only available for ADMIN users on GY Accounts.

- Clean the whole code and migrate entities from `record` to `class`.
- Add `create`, `update` (dynamic and null-ignorant), and `delete` operations.

***

Author: @gy-toxyc
Reviewer(s): @gy-toxyc
